### PR TITLE
ci: run npm test on PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
# What
- Add GitHub Actions workflow that runs 
pm ci + 
pm test

# Why
- Enforces the new test harness so we don’t regress silently.

# How to test
- Open this PR: the CI job should run automatically.
- After merge, pushes to main should also run the job.
