### PR TITLE
Preserve entered parameter values when re-rendering tool UI

### DIFF
--- a/js/models/Tool.js
+++ b/js/models/Tool.js
@@ -57,7 +57,7 @@ class Tool {
         };
     }
 
-    renderUI() {
+    renderUI(paramValues = {}) {
         // console.log(`Rendering UI for ${this.constructor.name}`);
         const toolSelection = document.getElementById('toolSelection');
         const toolDetails = document.getElementById('toolDetails');
@@ -81,6 +81,9 @@ class Tool {
             let paramInput;
             let paramSlider;
 
+            const hasValue = Object.prototype.hasOwnProperty.call(paramValues, param.name);
+            const value = hasValue ? paramValues[param.name] : param.defaultValue;
+
             if (param.type === "dropdown") {
                 paramInput = document.createElement('select');
                 paramInput.id = `param-${param.name}`;
@@ -93,7 +96,7 @@ class Tool {
                 paramInput = document.createElement('input');
                 paramInput.type = "number";
                 paramInput.id = `param-${param.name}`;
-                paramInput.value = param.defaultValue;
+                paramInput.value = value;
                 paramInput.step = param.type === "int" ? "1" : "0.1";
                 
                 // Add min/max if defined
@@ -104,7 +107,7 @@ class Tool {
                 paramSlider = document.createElement('input');
                 paramSlider.type = "range";
                 paramSlider.classList.add('param-slider');
-                paramSlider.value = param.defaultValue;
+                paramSlider.value = value;
                 paramSlider.step = param.type === "int" ? "1" : "0.1";
                 
                 // Set min/max for slider
@@ -132,12 +135,12 @@ class Tool {
                 paramInput = document.createElement('input');
                 paramInput.type = "checkbox";
                 paramInput.id = `param-${param.name}`;
-                paramInput.value = param.defaultValue;
+                paramInput.checked = !!value;
             } else if (param.type === "text") {
                 paramInput = document.createElement('input');
                 paramInput.type = "text";
                 paramInput.id = `param-${param.name}`;
-                paramInput.value = param.defaultValue;
+                paramInput.value = value;
             } else if (param.type === "file") {
                 paramInput = document.createElement('input');
                 paramInput.type = "file";
@@ -225,6 +228,7 @@ class Tool {
     reRenderOnExecute(exec) {
         return async () => {
             const toolContent = document.getElementById('toolContent');
+            const paramValues = this.collectParamsFromDOM();
             
             // Start loading animation (pulsing background of toolContent div)
             toolContent.classList.add('pulsate');
@@ -259,7 +263,7 @@ class Tool {
                 statusMessage.textContent = status.message;
                 
                 // Re-render the UI
-                this.renderUI();
+                this.renderUI(paramValues);
             }
         };
     }

--- a/js/models/Tool.test.js
+++ b/js/models/Tool.test.js
@@ -113,4 +113,28 @@ describe('Tool base architecture', () => {
     expect(tool.getStatus().message).toBe('boom');
     expect(document.getElementById('statusMessageText').textContent).toBe('boom');
   });
+
+  test('execute wrapper re-renders with last entered params instead of defaults', async () => {
+    class DemoTool extends Tool {
+      constructor() {
+        super('Demo', [
+          { name: 'Count', type: 'int', defaultValue: 1, min: 0, max: 10 },
+          { name: 'Enabled', type: 'boolean', defaultValue: false },
+        ], 'demo', null);
+      }
+      async run() {
+        this.setStatus(0, 'ran');
+      }
+    }
+
+    const tool = new DemoTool();
+    tool.renderUI();
+    document.getElementById('param-Count').value = '7';
+    document.getElementById('param-Enabled').checked = true;
+
+    await tool.execute();
+
+    expect(document.getElementById('param-Count').value).toBe('7');
+    expect(document.getElementById('param-Enabled').checked).toBe(true);
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent user inputs from being reset to defaults after a tool run and improve UX by preserving the last-entered parameter values across re-renders.
- Ensure numeric sliders and checkbox states reflect the most recent values rather than always using `defaultValue`.

### Description
- Added an optional `paramValues` argument to `renderUI` and use it to prefer user-entered values over `defaultValue` when populating inputs. 
- For numeric parameters, set both the number input and associated range slider from the computed `value`, and keep linking between them intact. 
- For boolean parameters, set the checkbox using `.checked` based on the provided `paramValues`. 
- In `reRenderOnExecute`, capture current DOM parameter values via `collectParamsFromDOM()` before running the execution and pass them to `renderUI` after the run so the UI re-renders with the last-entered values. 
- Added a unit test to `Tool.test.js` to assert re-render preserves user-entered numeric and boolean values.

### Testing
- Ran the `Tool` unit test suite (`js/models/Tool.test.js`) which includes the new test `execute wrapper re-renders with last entered params instead of defaults` and existing execution/download/error tests. 
- All automated tests in the `Tool` test file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e8bf11c883279ef8e6157086d687)