### PR TITLE
feat: add popups to all layers on click

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -409,15 +409,12 @@ function applyMapFeatureSelection(targetLayer, parentLayerId, fallbackIndex = 0,
     if (shouldSelectForMapInteractionMode(activeMapInteractionMode)) {
         state.setActiveLayerId(layerId);
         state.setSelectedFeatureIds(layerId, featureId ? [featureId] : []);
-
-        if (map && typeof map.closePopup === 'function') {
-            map.closePopup();
-        }
         refreshSidebarState();
-    } else {
-        if (!openFeaturePopup(targetLayer, layerId, featureId, fallbackIndex) && map && typeof map.closePopup === 'function') {
-            map.closePopup();
-        }
+    }
+
+    // Always show popup with feature attributes regardless of mode
+    if (!openFeaturePopup(targetLayer, layerId, featureId, fallbackIndex) && map && typeof map.closePopup === 'function') {
+        map.closePopup();
     }
 
     closeLayerMenu();
@@ -1188,14 +1185,16 @@ map.on('draw:deleted', function (e) {
 
 map.on('layeradd', function (e) {
     let layer = e.layer;
-    // if layer has a feature.toolMetadata, add the layer to the TOC
-    if (layer.hasOwnProperty('feature') && layer.feature.toolMetadata) {
-        const stableId = state.registerLayer(layer, layer?.feature?.properties?.__id);
+    // Bind selection/popup interaction to any layer with a feature property
+    if (layer.hasOwnProperty('feature') && layer.feature) {
+        if (layer.feature.toolMetadata) {
+            const stableId = state.registerLayer(layer, layer?.feature?.properties?.__id);
+            if (!tocLayers.includes(layer)) tocLayers.push(layer);
+            const importSummary = layer.feature?.properties?.importSummary;
+            if (importSummary) renderImportSummary(importSummary);
+            refreshSidebarState();
+        }
         bindLayerSelectionInteraction(layer);
-        if (!tocLayers.includes(layer)) tocLayers.push(layer);
-        const importSummary = layer.feature?.properties?.importSummary;
-        if (importSummary) renderImportSummary(importSummary);
-        refreshSidebarState();
     }
 });
 

--- a/js/tools/AddAIGeneratedFieldTool.js
+++ b/js/tools/AddAIGeneratedFieldTool.js
@@ -29,15 +29,6 @@ function coerceOutputValue(value, outputType) {
   return String(value);
 }
 
-function buildPopupContent(properties) {
-  let popupContent = "<table class='popupTable'>";
-  for (const [key, value] of Object.entries(properties)) {
-    popupContent += `<tr><td><b>${key}</b></td><td>${value}</td></tr>`;
-  }
-  popupContent += '</table>';
-  return popupContent;
-}
-
 class AddAIGeneratedFieldTool extends Tool {
   constructor() {
     super('Add AI-Generated Field', [
@@ -174,10 +165,6 @@ class AddAIGeneratedFieldTool extends Tool {
         params,
         timestamp: new Date().toISOString(),
       };
-
-      if (typeof layer.bindPopup === 'function') {
-        layer.bindPopup(buildPopupContent(layer.feature.properties));
-      }
     }
 
     this.setStatus(0, `Updated ${eligibleTargets.length} feature(s).`);

--- a/js/tools/GenerateAIFeatures.js
+++ b/js/tools/GenerateAIFeatures.js
@@ -1,6 +1,6 @@
 const { Tool } = require('../models/Tool');
 const { Parameter } = require('../models/Parameter');
-const { applyResult, getLayer } = require('../state');
+const { applyResult } = require('../state');
 const { STORAGE_KEYS, DEFAULT_PROVIDER, AI_PROVIDERS } = require('../ai-providers');
 
 /**
@@ -68,20 +68,6 @@ class GenerateAIFeatures extends Tool {
         const res = applyResult({ addGeojson: data });
 
         if (res && res.ok) {
-            for (const id of (res.added || [])) {
-                const addedLayer = getLayer(id);
-                if (!addedLayer || !addedLayer.feature || !addedLayer.feature.properties) continue;
-
-                const attributes = addedLayer.feature.properties;
-                let popupContent = "<table class='popupTable'>";
-                for (let key in attributes) {
-                    popupContent += `<tr><td><b>${key.charAt(0).toUpperCase() + key.slice(1)}</b></td><td>${attributes[key]}</td></tr>`;
-                }
-                popupContent += "</table>";
-                if (typeof addedLayer.bindPopup === 'function') {
-                    addedLayer.bindPopup(popupContent);
-                }
-            }
             this.setStatus(0, 'AI features added to map.');
             return res;
         }


### PR DESCRIPTION
## Summary

Show feature attribute popups consistently when clicking any feature on the map, regardless of interaction mode.

**Before:** Popups only appeared in Inspect mode. In Select mode, clicking a feature closed any open popup. Some tools (GenerateAIFeatures, AddAIGeneratedFieldTool) manually bound popups, creating inconsistent behavior.

**After:** Clicking any feature always shows an attribute popup. Mode toggle still works:
- **Select mode**: click selects the feature AND shows popup
- **Inspect mode**: click shows popup without changing selection

## Changes

| File | Change |
|------|--------|
| `js/app.js` | `applyMapFeatureSelection` always opens popup; relaxed `layeradd` handler to catch all layers with features |
| `js/tools/GenerateAIFeatures.js` | Removed manual `bindPopup` loop (now handled centrally) |
| `js/tools/AddAIGeneratedFieldTool.js` | Removed `buildPopupContent` helper and manual `bindPopup` call |

## Testing

All 15 existing test suites pass (47+ tests). No test changes needed.

Closes #8