### PR TITLE
Add headless demo workflow for issue #100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 *.log
 .vscode/
+artifacts/

--- a/docs/headless-api.md
+++ b/docs/headless-api.md
@@ -109,11 +109,23 @@ All successful tool calls and tool-level validation failures use the same envelo
     "added": [],
     "removed": [],
     "bbox": [-118.5, 33.5, -117.5, 34.5]
+  },
+  "execution": {
+    "startedAt": "2026-07-21T03:27:44.000Z",
+    "finishedAt": "2026-07-21T03:27:44.012Z",
+    "durationMs": 12,
+    "inputLayerIds": ["source-layer"],
+    "outputLayerIds": ["result-1"],
+    "featureCounts": {
+      "input": 3,
+      "output": 3
+    }
   }
 }
 ```
 
 For feature-collection tools, the updated FeatureCollection is returned in top-level `state`. The `output` object contains operation details such as counts and updated ids, not a nested state copy.
+`execution` is the API-level receipt used by the demo client and tests. It keeps the runtime inspectable without forcing every tool to share the same internal output shape.
 
 ## Validation Failures
 
@@ -137,6 +149,17 @@ Tools run `validate(params, context)` before execution. Tool-level validation fa
     "added": [],
     "removed": [],
     "bbox": null
+  },
+  "execution": {
+    "startedAt": "2026-07-21T03:27:44.000Z",
+    "finishedAt": "2026-07-21T03:27:44.001Z",
+    "durationMs": 1,
+    "inputLayerIds": [],
+    "outputLayerIds": [],
+    "featureCounts": {
+      "input": 0,
+      "output": 0
+    }
   }
 }
 ```
@@ -167,14 +190,14 @@ npm test -- --runInBand server.headless.test.js
 
 It is designed to be:
 
-- easy to call from a future CLI wrapper
+- easy to call from a repo-native CLI/demo wrapper
 - simple for MCP/agent adapters to serialize
 - explicit about inputs and outputs
 - non-breaking for the existing browser UI
 
 ## Next likely steps
 
-1. add a small CLI wrapper around `POST /api/run`
+1. extend the demo contract to more tools after the chained `RandomPointsTool -> BufferTool -> ExportTool` flow is stable
 2. make `AddDataTool` accept JSON/file-path friendly server inputs
 3. decouple AI geometry generation from browser localStorage
 4. build an MCP-facing adapter on top of this contract

--- a/docs/headless-demo.md
+++ b/docs/headless-demo.md
@@ -1,0 +1,78 @@
+# Headless Demo
+
+This is the narrow proof artifact for issue `#100`.
+
+It proves that Spatial Workbench can behave like a callable spatial runtime outside the browser by:
+
+- discovering callable tools from `GET /api/run`
+- executing `RandomPointsTool -> BufferTool -> ExportTool`
+- passing the returned serialized `state` from each response into the next request unchanged
+- writing a final GeoJSON artifact to disk
+
+## Run It
+
+Start from the repo root:
+
+```bash
+node scripts/headless-demo.js
+```
+
+By default, the script starts the Express app on an ephemeral local port, runs the three-step flow, then shuts the server down.
+
+To point at an already-running API instead:
+
+```bash
+HEADLESS_API_URL=http://127.0.0.1:3000 node scripts/headless-demo.js
+```
+
+## Expected Receipts
+
+The script prints one compact receipt per step, for example:
+
+```text
+Started local headless API at http://127.0.0.1:43219
+[1/3] RandomPointsTool | status=0:Added 5 point(s). | duration=8ms | inputLayers=none | outputLayers=result-1 | features=0->5
+[2/3] BufferTool | status=0:Buffered layer added to map. | duration=14ms | inputLayers=result-1 | outputLayers=result-2 | features=5->5
+[3/3] ExportTool | status=0:Prepared GeoJSON export. | duration=2ms | inputLayers=result-2 | outputLayers=none | features=5->5
+Wrote /path/to/repo/artifacts/headless-demo.geojson
+```
+
+The exact ids, timings, and output port will vary. The important part is that each step exposes:
+
+- tool status
+- duration
+- input layer ids
+- output layer ids
+- input/output feature counts
+
+## Output File
+
+The final export is written to:
+
+```text
+artifacts/headless-demo.geojson
+```
+
+That file is ignored by Git so the demo can be rerun locally without polluting the working tree.
+
+## Request Transitions
+
+The chained flow is:
+
+1. `RandomPointsTool` receives only a fixed `bbox` and point count.
+2. `BufferTool` receives the entire `state` returned by step 1 and targets the layer id from step 1's receipt.
+3. `ExportTool` receives the entire `state` returned by step 2 and targets the buffered layer id from step 2's receipt.
+
+The caller should not guess generated layer ids or rebuild state by hand. The response `state` is the authoritative serialized handoff between steps.
+
+## What This Defers
+
+This demo intentionally does not prove:
+
+- browser upload flows like `AddDataTool`
+- AI-provider-dependent tools
+- persisted sessions or server-side state storage
+- MCP wrapping
+- full internal runtime unification
+
+It is the smallest repo-native artifact that proves the existing headless seam is already usable from an external caller.

--- a/js/headless-runtime.js
+++ b/js/headless-runtime.js
@@ -63,6 +63,30 @@ function createLayerRecord(rawLayer, fallbackIndex = 0) {
   };
 }
 
+function createUniqueLayerId(registry, preferredId) {
+  if (preferredId && !registry.has(preferredId)) {
+    return preferredId;
+  }
+
+  if (preferredId) {
+    let suffix = 2;
+    let candidate = `${preferredId}-${suffix}`;
+    while (registry.has(candidate)) {
+      suffix += 1;
+      candidate = `${preferredId}-${suffix}`;
+    }
+    return candidate;
+  }
+
+  let index = 1;
+  let candidate = `result-${index}`;
+  while (registry.has(candidate)) {
+    index += 1;
+    candidate = `result-${index}`;
+  }
+  return candidate;
+}
+
 function createHeadlessRuntime(input = {}) {
   const initialLayers = Array.isArray(input.layers) ? input.layers : [];
   const layerRecords = initialLayers.map((layer, index) => createLayerRecord(layer, index));
@@ -114,10 +138,11 @@ function createHeadlessRuntime(input = {}) {
       : (toolResult.addGeojson ? [toolResult.addGeojson] : []);
 
     additions.forEach((geojson, index) => {
-      const nextId = geojson?.feature?.properties?.__id
+      const preferredId = geojson?.feature?.properties?.__id
         || geojson?.properties?.__id
         || geojson?.toolMetadata?.layerId
-        || `result-${added.length + index + 1}`;
+        || null;
+      const nextId = createUniqueLayerId(registry, preferredId);
       const name = geojson?.properties?.name || geojson?.toolMetadata?.name || nextId;
       const record = createLayerRecord({ id: nextId, name, geojson }, added.length + index);
       registry.set(record.id, record);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8431,9 +8431,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/headless-demo.js
+++ b/scripts/headless-demo.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+function requestJson(baseUrl, requestPath, options = {}) {
+  const url = new URL(requestPath, baseUrl);
+  const body = options.body ? JSON.stringify(options.body) : null;
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, {
+      method: options.method || 'GET',
+      headers: body
+        ? {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+          }
+        : {},
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        let parsed;
+        try {
+          parsed = JSON.parse(data || '{}');
+        } catch (error) {
+          reject(new Error(`Failed to parse ${requestPath} response: ${error.message}`));
+          return;
+        }
+
+        resolve({
+          status: res.statusCode,
+          ok: res.statusCode >= 200 && res.statusCode < 300,
+          data: parsed,
+        });
+      });
+    });
+
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+function formatReceipt(stepNumber, toolKey, response) {
+  const execution = response.execution || {};
+  const status = response.status || {};
+  const inputLayerIds = execution.inputLayerIds || [];
+  const outputLayerIds = execution.outputLayerIds || [];
+  const featureCounts = execution.featureCounts || {};
+
+  return [
+    `[${stepNumber}/3] ${toolKey}`,
+    `status=${status.code}:${status.message || 'unknown'}`,
+    `duration=${execution.durationMs ?? '?'}ms`,
+    `inputLayers=${inputLayerIds.length ? inputLayerIds.join(',') : 'none'}`,
+    `outputLayers=${outputLayerIds.length ? outputLayerIds.join(',') : 'none'}`,
+    `features=${featureCounts.input ?? 0}->${featureCounts.output ?? 0}`,
+  ].join(' | ');
+}
+
+function getAddedLayerId(response, toolKey) {
+  const layerId = response?.state?.added?.[0]?.id;
+  if (!layerId) {
+    throw new Error(`${toolKey} did not return an added layer receipt.`);
+  }
+  return layerId;
+}
+
+function assertOk(response, label) {
+  if (!response.ok) {
+    throw new Error(`${label} failed: ${response.error || 'HTTP error'}`);
+  }
+  if (!response.data?.ok) {
+    const message = response.data?.status?.message || response.data?.error || 'Unknown tool error';
+    throw new Error(`${label} failed: ${message}`);
+  }
+}
+
+async function startLocalServer() {
+  global.turf = require('@turf/turf');
+  global.L = { Polygon: function Polygon() {} };
+
+  const { app } = require('../server');
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    },
+  };
+}
+
+async function main() {
+  let runtime = null;
+  let baseUrl = process.env.HEADLESS_API_URL;
+
+  try {
+    if (!baseUrl) {
+      runtime = await startLocalServer();
+      baseUrl = runtime.baseUrl;
+      console.log(`Started local headless API at ${baseUrl}`);
+    } else {
+      console.log(`Using headless API at ${baseUrl}`);
+    }
+
+    const discovery = await requestJson(baseUrl, '/api/run');
+    assertOk(discovery, 'Discovery');
+
+    const supportedTools = Array.isArray(discovery.data.supportedTools) ? discovery.data.supportedTools : [];
+    const requiredTools = ['RandomPointsTool', 'BufferTool', 'ExportTool'];
+    const advertisedTools = new Set(supportedTools.map((tool) => tool.key));
+    requiredTools.forEach((toolKey) => {
+      if (!advertisedTools.has(toolKey)) {
+        throw new Error(`Discovery is missing required tool ${toolKey}.`);
+      }
+    });
+
+    let state = {
+      bbox: [-118.5, 33.5, -118.2, 33.8],
+    };
+
+    const randomPoints = await requestJson(baseUrl, '/api/run', {
+      method: 'POST',
+      body: {
+        tool: 'RandomPointsTool',
+        params: {
+          'Points Count': 5,
+          'Inside Polygon': false,
+        },
+        state,
+      },
+    });
+    assertOk(randomPoints, 'RandomPointsTool');
+    console.log(formatReceipt(1, 'RandomPointsTool', randomPoints.data));
+    state = randomPoints.data.state;
+    const randomPointsLayerId = getAddedLayerId(randomPoints.data, 'RandomPointsTool');
+
+    const buffer = await requestJson(baseUrl, '/api/run', {
+      method: 'POST',
+      body: {
+        tool: 'BufferTool',
+        params: {
+          'Input Layer': randomPointsLayerId,
+          Distance: 0.5,
+          Units: 'kilometers',
+        },
+        state,
+      },
+    });
+    assertOk(buffer, 'BufferTool');
+    console.log(formatReceipt(2, 'BufferTool', buffer.data));
+    state = buffer.data.state;
+    const bufferedLayerId = getAddedLayerId(buffer.data, 'BufferTool');
+
+    const exportResult = await requestJson(baseUrl, '/api/run', {
+      method: 'POST',
+      body: {
+        tool: 'ExportTool',
+        params: {
+          Layer: bufferedLayerId,
+          Format: 'GeoJSON',
+        },
+        state,
+      },
+    });
+    assertOk(exportResult, 'ExportTool');
+    console.log(formatReceipt(3, 'ExportTool', exportResult.data));
+
+    const artifactData = exportResult.data?.output?.download?.data;
+    if (typeof artifactData !== 'string' || !artifactData.trim()) {
+      throw new Error('ExportTool did not return serialized GeoJSON data.');
+    }
+
+    const artifactDir = path.join(__dirname, '..', 'artifacts');
+    const artifactPath = path.join(artifactDir, 'headless-demo.geojson');
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.writeFileSync(artifactPath, `${artifactData}\n`, 'utf8');
+    console.log(`Wrote ${artifactPath}`);
+  } finally {
+    if (runtime) {
+      await runtime.close();
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/server.headless.test.js
+++ b/server.headless.test.js
@@ -123,6 +123,20 @@ function summarizeGroupFeatures(geojson) {
   };
 }
 
+function expectExecutionReceipt(execution) {
+  expect(execution).toEqual(expect.objectContaining({
+    startedAt: expect.any(String),
+    finishedAt: expect.any(String),
+    durationMs: expect.any(Number),
+    inputLayerIds: expect.any(Array),
+    outputLayerIds: expect.any(Array),
+    featureCounts: expect.objectContaining({
+      input: expect.any(Number),
+      output: expect.any(Number),
+    }),
+  }));
+}
+
 const sourcePointLayer = {
   id: 'source-layer',
   name: 'Sample source points',
@@ -202,6 +216,13 @@ describe('/api/run', () => {
         layers: expect.any(Array),
         bbox: [-1, -1, 1, 1],
       }),
+      execution: expect.any(Object),
+    }));
+    expectExecutionReceipt(data.execution);
+    expect(data.execution).toEqual(expect.objectContaining({
+      inputLayerIds: ['source-layer'],
+      outputLayerIds: [data.state.added[0].id],
+      featureCounts: { input: sourcePointsGeojson.features.length, output: sourcePointsGeojson.features.length },
     }));
     expect(data.state.added).toHaveLength(1);
     expect(data.state.layers).toHaveLength(2);
@@ -262,6 +283,7 @@ describe('/api/run', () => {
     expect(response.status).toBe(200);
     expect(data.ok).toBe(true);
     expect(data.status).toEqual(expect.objectContaining({ code: 0, message: 'Buffered layer added to map.' }));
+    expectExecutionReceipt(data.execution);
     expect(data.state.added).toHaveLength(1);
     const bufferLayer = data.state.added[0];
     expect(summarizeSingleFeatureBufferLayer(bufferLayer)).toEqual(expectedTurfBufferPolygonWithHolesSummary);
@@ -286,6 +308,12 @@ describe('/api/run', () => {
     expect(firstResponse.status).toBe(200);
     expect(firstData.ok).toBe(true);
     expect(firstData.status).toEqual(expect.objectContaining({ code: 0 }));
+    expectExecutionReceipt(firstData.execution);
+    expect(firstData.execution).toEqual(expect.objectContaining({
+      inputLayerIds: [],
+      outputLayerIds: [firstData.state.added[0].id],
+      featureCounts: { input: 0, output: 3 },
+    }));
     expect(firstData.output).toEqual(expect.objectContaining({ ok: true, added: expect.any(Array), removed: [] }));
     expect(firstData.state.bbox).toEqual([10, 20, 11, 21]);
     expect(firstData.state.added).toHaveLength(1);
@@ -318,6 +346,7 @@ describe('/api/run', () => {
     expect(secondResponse.status).toBe(200);
     expect(secondData.ok).toBe(false);
     expect(secondData.status).toEqual(expect.objectContaining({ code: 2, message: 'No layer selected.' }));
+    expectExecutionReceipt(secondData.execution);
     expect(secondData.output).toBe(null);
     expect(secondData.state).toEqual(expect.objectContaining({
       added: [],
@@ -346,6 +375,12 @@ describe('/api/run', () => {
     expect(response.status).toBe(200);
     expect(data.ok).toBe(true);
     expect(data.status).toEqual(expect.objectContaining({ code: 0, message: 'Prepared GeoJSON export.' }));
+    expectExecutionReceipt(data.execution);
+    expect(data.execution).toEqual(expect.objectContaining({
+      inputLayerIds: ['source-layer'],
+      outputLayerIds: [],
+      featureCounts: { input: sourcePointsGeojson.features.length, output: sourcePointsGeojson.features.length },
+    }));
     expect(data.output).toEqual(expect.objectContaining({
       download: expect.objectContaining({
         filename: 'source-layer.geojson',
@@ -375,6 +410,98 @@ describe('/api/run', () => {
     expect(data.details.supportedTools).toEqual(
       expect.arrayContaining(['BufferTool', 'RandomPointsTool', 'ExportTool'])
     );
+  });
+
+  test('POST /api/run chains RandomPointsTool to BufferTool to ExportTool using returned state verbatim', async () => {
+    const discoveryResponse = await requestJson(baseUrl, '/api/run');
+    const discoveryData = discoveryResponse.json();
+
+    expect(discoveryResponse.status).toBe(200);
+    expect(discoveryData.supportedTools.map((tool) => tool.key)).toEqual(expect.arrayContaining([
+      'RandomPointsTool',
+      'BufferTool',
+      'ExportTool',
+    ]));
+
+    const randomPointsResponse = await requestJson(baseUrl, '/api/run', {
+      method: 'POST',
+      body: {
+        tool: 'RandomPointsTool',
+        params: {
+          'Points Count': 4,
+          'Inside Polygon': false,
+        },
+        state: {
+          bbox: [10, 20, 11, 21],
+        },
+      },
+    });
+    const randomPointsData = randomPointsResponse.json();
+
+    expect(randomPointsResponse.status).toBe(200);
+    expect(randomPointsData.ok).toBe(true);
+    expectExecutionReceipt(randomPointsData.execution);
+    expect(randomPointsData.state.added).toHaveLength(1);
+    const randomPointsLayerId = randomPointsData.state.added[0].id;
+    const randomPointsLayer = randomPointsData.state.layers.find((layer) => layer.id === randomPointsLayerId);
+    expect(randomPointsLayer.geojson.features).toHaveLength(4);
+
+    const bufferResponse = await requestJson(baseUrl, '/api/run', {
+      method: 'POST',
+      body: {
+        tool: 'BufferTool',
+        params: {
+          'Input Layer': randomPointsLayerId,
+          Distance: 0.5,
+          Units: 'kilometers',
+        },
+        state: randomPointsData.state,
+      },
+    });
+    const bufferData = bufferResponse.json();
+
+    expect(bufferResponse.status).toBe(200);
+    expect(bufferData.ok).toBe(true);
+    expectExecutionReceipt(bufferData.execution);
+    expect(bufferData.execution).toEqual(expect.objectContaining({
+      inputLayerIds: [randomPointsLayerId],
+      outputLayerIds: [bufferData.state.added[0].id],
+      featureCounts: { input: 4, output: 4 },
+    }));
+    expect(bufferData.state.layers.map((layer) => layer.id)).toEqual(expect.arrayContaining([
+      randomPointsLayerId,
+      bufferData.state.added[0].id,
+    ]));
+    expect(bufferData.state.added[0].id).not.toBe(randomPointsLayerId);
+    const bufferedLayerId = bufferData.state.added[0].id;
+    const bufferedLayer = bufferData.state.layers.find((layer) => layer.id === bufferedLayerId);
+    expect(bufferedLayer.geojson.toolMetadata.parentLayerId).toBe(randomPointsLayerId);
+    expect(bufferedLayer.geojson.features).toHaveLength(4);
+
+    const exportResponse = await requestJson(baseUrl, '/api/run', {
+      method: 'POST',
+      body: {
+        tool: 'ExportTool',
+        params: {
+          Layer: bufferedLayerId,
+          Format: 'GeoJSON',
+        },
+        state: bufferData.state,
+      },
+    });
+    const exportData = exportResponse.json();
+
+    expect(exportResponse.status).toBe(200);
+    expect(exportData.ok).toBe(true);
+    expectExecutionReceipt(exportData.execution);
+    expect(exportData.execution).toEqual(expect.objectContaining({
+      inputLayerIds: [bufferedLayerId],
+      outputLayerIds: [],
+      featureCounts: { input: 4, output: 4 },
+    }));
+    const exportedGeojson = JSON.parse(exportData.output.download.data);
+    expect(turf.getType(exportedGeojson)).toBe('FeatureCollection');
+    expect(exportedGeojson.features).toHaveLength(bufferedLayer.geojson.features.length);
   });
 
   test('POST /api/run reports tool validation failures without crashing the API', async () => {
@@ -433,6 +560,7 @@ describe('/api/run', () => {
       expect(response.status).toBe(200);
       expect(data.ok).toBe(false);
       expect(data.status).toEqual(expect.objectContaining(scenario.expectedStatus));
+      expectExecutionReceipt(data.execution);
       expect(data.validation).toEqual(expect.objectContaining({
         ok: false,
         errors: expect.arrayContaining([scenario.expectedStatus.message]),
@@ -466,6 +594,7 @@ describe('/api/run', () => {
     expect(response.status).toBe(200);
     expect(data.ok).toBe(true);
     expect(data.status).toEqual(expect.objectContaining({ code: 0, message: 'Added 2 point(s).' }));
+    expectExecutionReceipt(data.execution);
     expect(data.output).toEqual(expect.objectContaining({ ok: true, added: expect.any(Array), removed: [] }));
     expect(data.state.added).toHaveLength(1);
     expect(data.state.layers).toHaveLength(2);
@@ -510,6 +639,7 @@ describe('/api/run', () => {
     expect(response.status).toBe(200);
     expect(data.ok).toBe(true);
     expect(data.status).toEqual(expect.objectContaining({ code: 0, message: 'Added 5 point(s).' }));
+    expectExecutionReceipt(data.execution);
     const resultLayer = data.state.added[0];
     expect(resultLayer.geojson.features).toHaveLength(5);
     resultLayer.geojson.features.forEach((feature) => {

--- a/server.js
+++ b/server.js
@@ -29,6 +29,73 @@ require('dotenv').config();
 
 app.use(express.json());
 
+function countGeojsonFeatures(geojson) {
+  if (!geojson || typeof geojson !== 'object') return 0;
+  if (geojson.type === 'FeatureCollection') {
+    return Array.isArray(geojson.features) ? geojson.features.length : 0;
+  }
+  if (geojson.type === 'Feature') return 1;
+  if (typeof geojson.type === 'string') return 1;
+  return 0;
+}
+
+function getLayerFeatureCount(state, layerId) {
+  const layer = Array.isArray(state?.layers) ? state.layers.find((entry) => entry.id === layerId) : null;
+  return countGeojsonFeatures(layer?.geojson);
+}
+
+function collectInputLayerIds(toolKey, params = {}) {
+  const ids = [];
+
+  if (typeof params['Input Layer'] === 'string' && params['Input Layer']) {
+    ids.push(params['Input Layer']);
+  }
+  if (typeof params.Layer === 'string' && params.Layer) {
+    ids.push(params.Layer);
+  }
+  if (toolKey === 'RandomPointsTool' && params['Inside Polygon'] && typeof params.Polygon === 'string' && params.Polygon) {
+    ids.push(params.Polygon);
+  }
+
+  return [...new Set(ids)];
+}
+
+function buildExecutionReceipt({ toolKey, params, requestState, result, startedAt, finishedAt }) {
+  const inputLayerIds = collectInputLayerIds(toolKey, params);
+  const outputLayerIds = Array.isArray(result?.state?.added)
+    ? result.state.added.map((layer) => layer.id).filter(Boolean)
+    : [];
+
+  let inputFeatureCount = inputLayerIds.reduce((sum, layerId) => sum + getLayerFeatureCount(requestState, layerId), 0);
+  if (!inputFeatureCount && requestState?.featureCollection) {
+    inputFeatureCount = countGeojsonFeatures(requestState.featureCollection);
+  }
+
+  let outputFeatureCount = outputLayerIds.reduce((sum, layerId) => sum + getLayerFeatureCount(result?.state, layerId), 0);
+  if (!outputFeatureCount && result?.state?.featureCollection) {
+    outputFeatureCount = countGeojsonFeatures(result.state.featureCollection);
+  }
+  if (!outputFeatureCount && result?.output?.download?.data) {
+    try {
+      outputFeatureCount = countGeojsonFeatures(JSON.parse(result.output.download.data));
+    } catch (_error) {
+      outputFeatureCount = 0;
+    }
+  }
+
+  return {
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    inputLayerIds,
+    outputLayerIds,
+    featureCounts: {
+      input: inputFeatureCount,
+      output: outputFeatureCount,
+    },
+  };
+}
+
 function normalizeOllamaUrl(value) {
   const base = (value || DEFAULT_OLLAMA_URL).trim() || DEFAULT_OLLAMA_URL;
   return base.replace(/\/+$/, '');
@@ -198,6 +265,7 @@ app.get('/api/run', (_req, res) => {
 app.post('/api/run', async (req, res) => {
   try {
     const body = req.body || {};
+    const startedAt = new Date();
     const result = body?.state?.featureCollection
       ? await runToolHeadlessly({
           toolKey: body.tool,
@@ -205,7 +273,19 @@ app.post('/api/run', async (req, res) => {
           state: body.state,
         })
       : await runHeadlessTool(body);
-    res.json(result);
+    const finishedAt = new Date();
+
+    res.json({
+      ...result,
+      execution: buildExecutionReceipt({
+        toolKey: body.tool,
+        params: body.params,
+        requestState: body.state,
+        result,
+        startedAt,
+        finishedAt,
+      }),
+    });
   } catch (error) {
     const statusCode = error.statusCode || 500;
     res.status(statusCode).json({


### PR DESCRIPTION
## Summary
- add a repo-native `scripts/headless-demo.js` client for the canonical `RandomPointsTool -> BufferTool -> ExportTool` flow
- add API-level execution receipts plus a chained HTTP test that passes returned `state` between calls verbatim
- document the focused demo flow in `docs/headless-demo.md` and update the headless API contract notes

## Verification
- `npm test -- --runInBand server.headless.test.js`
- `node scripts/headless-demo.js`
- `npm run build`

Closes #100
